### PR TITLE
Add CODEOWNERS and enable Copilot PR reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# All files are owned by @rcarson.
+# @github-copilot is added as a reviewer to provide automated code review on every PR.
+* @rcarson @github-copilot

--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,10 @@
 !*.json
 !*.yaml
 !examples/
+!.github/CODEOWNERS
 !.github/workflows/ci.yaml
 !.github/workflows/release.yaml
+!.github/dependabot.yaml
 !.pre-commit-config.yaml
 !.golangci.yaml
 


### PR DESCRIPTION
Adds `.github/CODEOWNERS` designating `@rcarson` as owner of all files and `@github-copilot` as an automatic reviewer on every PR. Also adds `!.github/dependabot.yaml` to the gitignore allowlist which was missing.

Closes #28