### PR TITLE
Add EXPOSE 2112 to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,6 @@ COPY --from=builder /stack-agent /stack-agent
 USER agent
 WORKDIR /opt/stack-agent
 
+EXPOSE 2112
+
 ENTRYPOINT ["/stack-agent"]


### PR DESCRIPTION
Closes #30.

## Summary
- Adds `EXPOSE 2112` to the runtime stage of the Dockerfile
- Documents the default port for `/healthz` and `/metrics` endpoints

## Test plan
- [ ] CI passes