### PR TITLE
chore: update module path and image refs after org transfer

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/rcarson/stack-agent
+          images: ghcr.io/b0rked-dev/stack-agent
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The `examples/docker-compose/compose.yaml` in this repository is the deployment 
 ```yaml
 services:
   stack-agent:
-    image: ghcr.io/rcarson/stack-agent:latest
+    image: ghcr.io/b0rked-dev/stack-agent:latest
     restart: unless-stopped
     ports:
       - "2112:2112"

--- a/cmd/stack-agent/main.go
+++ b/cmd/stack-agent/main.go
@@ -14,13 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/rcarson/stack-agent/internal/agent"
-	"github.com/rcarson/stack-agent/internal/compose"
-	"github.com/rcarson/stack-agent/internal/config"
-	"github.com/rcarson/stack-agent/internal/git"
-	"github.com/rcarson/stack-agent/internal/metrics"
-	"github.com/rcarson/stack-agent/internal/server"
-	"github.com/rcarson/stack-agent/internal/state"
+	"github.com/b0rked-dev/stack-agent/internal/agent"
+	"github.com/b0rked-dev/stack-agent/internal/compose"
+	"github.com/b0rked-dev/stack-agent/internal/config"
+	"github.com/b0rked-dev/stack-agent/internal/git"
+	"github.com/b0rked-dev/stack-agent/internal/metrics"
+	"github.com/b0rked-dev/stack-agent/internal/server"
+	"github.com/b0rked-dev/stack-agent/internal/state"
 )
 
 // Version is set at build time via -ldflags "-X main.Version=<tag>".

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -1,6 +1,6 @@
 services:
   stack-agent:
-    image: ghcr.io/rcarson/stack-agent:latest
+    image: ghcr.io/b0rked-dev/stack-agent:latest
     restart: unless-stopped
     ports:
       - "2112:2112"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/rcarson/stack-agent
+module github.com/b0rked-dev/stack-agent
 
 go 1.26
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/rcarson/stack-agent/internal/compose"
-	"github.com/rcarson/stack-agent/internal/config"
-	"github.com/rcarson/stack-agent/internal/git"
-	"github.com/rcarson/stack-agent/internal/metrics"
-	"github.com/rcarson/stack-agent/internal/state"
+	"github.com/b0rked-dev/stack-agent/internal/compose"
+	"github.com/b0rked-dev/stack-agent/internal/config"
+	"github.com/b0rked-dev/stack-agent/internal/git"
+	"github.com/b0rked-dev/stack-agent/internal/metrics"
+	"github.com/b0rked-dev/stack-agent/internal/state"
 )
 
 // Stack is a single stack poller. One goroutine per configured stack.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rcarson/stack-agent/internal/config"
-	"github.com/rcarson/stack-agent/internal/metrics"
+	"github.com/b0rked-dev/stack-agent/internal/config"
+	"github.com/b0rked-dev/stack-agent/internal/metrics"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/metrics/recorder_test.go
+++ b/internal/metrics/recorder_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/b0rked-dev/stack-agent/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
-	"github.com/rcarson/stack-agent/internal/metrics"
 )
 
 // gatherCounter gathers all metrics from reg and returns the value of the

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/b0rked-dev/stack-agent/internal/server"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/rcarson/stack-agent/internal/server"
 )
 
 func TestHealthz(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rcarson/stack-agent/internal/agent"
-	"github.com/rcarson/stack-agent/internal/compose"
-	"github.com/rcarson/stack-agent/internal/config"
-	"github.com/rcarson/stack-agent/internal/git"
-	"github.com/rcarson/stack-agent/internal/state"
+	"github.com/b0rked-dev/stack-agent/internal/agent"
+	"github.com/b0rked-dev/stack-agent/internal/compose"
+	"github.com/b0rked-dev/stack-agent/internal/config"
+	"github.com/b0rked-dev/stack-agent/internal/git"
+	"github.com/b0rked-dev/stack-agent/internal/state"
 )
 
 const (


### PR DESCRIPTION
Closes #34.

## Summary
- `go.mod` module path: `github.com/rcarson/stack-agent` → `github.com/b0rked-dev/stack-agent`
- All Go import paths updated
- `ghcr.io/rcarson/stack-agent` → `ghcr.io/b0rked-dev/stack-agent` in README, compose example, and release workflow

## Test plan
- [ ] CI passes