### PR TITLE
ci: eliminate duplicate builds on PR pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - "**"
+      - main
   pull_request:
     branches:
       - main


### PR DESCRIPTION
Closes #36.

## Summary
- Restricts `push` trigger to `main` only (was `**`)
- `pull_request` already covers feature branches — no coverage lost

## Test plan
- [ ] CI passes on this PR (only one run, not two)