### PR TITLE
chore: rename project from stack-agent to steward

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/b0rked-dev/stack-agent
+          images: ghcr.io/b0rked-dev/steward
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/AGENT.md
+++ b/AGENT.md
@@ -1,4 +1,4 @@
-# stack-agent — Agent Instructions
+# steward — Agent Instructions
 
 ## Branching and pull requests
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,17 +3,17 @@ FROM golang:1.26-alpine AS builder
 ARG VERSION=dev
 WORKDIR /build
 COPY . .
-RUN go build -ldflags "-X main.Version=${VERSION}" -o /stack-agent ./cmd/stack-agent
+RUN go build -ldflags "-X main.Version=${VERSION}" -o /steward ./cmd/steward
 
 FROM alpine:3.21
 
-RUN adduser -D -u 1000 agent && mkdir -p /opt/stack-agent/data && chown -R agent:agent /opt/stack-agent
+RUN adduser -D -u 1000 agent && mkdir -p /opt/steward/data && chown -R agent:agent /opt/steward
 
-COPY --from=builder /stack-agent /stack-agent
+COPY --from=builder /steward /steward
 
 USER agent
-WORKDIR /opt/stack-agent
+WORKDIR /opt/steward
 
 EXPOSE 2112
 
-ENTRYPOINT ["/stack-agent"]
+ENTRYPOINT ["/steward"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# stack-agent
+# steward
 
-A lightweight per-host daemon written in Go that watches Git repositories for changes to Docker Compose stacks and reconciles the running state automatically. Each host runs its own agent instance — there is no coordinator, no database, and no UI. State is minimal and local.
+**Continuous reconciliation for Docker Compose stacks.**
+
+A lightweight per-host daemon written in Go that watches Git repositories for changes to Docker Compose stacks and reconciles the running state automatically. Each host runs its own instance — there is no coordinator, no database, and no UI. State is minimal and local.
 
 ## How it works
 
@@ -22,43 +24,43 @@ Git operations use [go-git](https://github.com/go-git/go-git), a pure Go impleme
 **1. Create the directory layout on the host.**
 
 ```bash
-mkdir -p /opt/stack-agent/data
+mkdir -p /opt/steward/data
 ```
 
 **2. Write a config file.**
 
 ```bash
-cp config.example.yaml /opt/stack-agent/config.yaml
-# Edit /opt/stack-agent/config.yaml for your stacks
+cp config.example.yaml /opt/steward/config.yaml
+# Edit /opt/steward/config.yaml for your stacks
 ```
 
 **3. Create a `.env` file with any tokens (chmod 600).**
 
 ```bash
-# /opt/stack-agent/.env
-STACK_AGENT_DEFAULT_TOKEN=ghp_abc123...
-chmod 600 /opt/stack-agent/.env
+# /opt/steward/.env
+STEWARD_DEFAULT_TOKEN=ghp_abc123...
+chmod 600 /opt/steward/.env
 ```
 
 **4. Deploy with Docker Compose.**
 
 ```bash
-cd /opt/stack-agent && docker compose up -d
+cd /opt/steward && docker compose up -d
 ```
 
-The `examples/docker-compose/compose.yaml` in this repository is the deployment manifest for the agent itself. Copy it to `/opt/stack-agent/compose.yaml` and adjust the volume mounts if needed:
+The `examples/docker-compose/compose.yaml` in this repository is the deployment manifest for the agent itself. Copy it to `/opt/steward/compose.yaml` and adjust the volume mounts if needed:
 
 ```yaml
 services:
-  stack-agent:
-    image: ghcr.io/b0rked-dev/stack-agent:latest
+  steward:
+    image: ghcr.io/b0rked-dev/steward:latest
     restart: unless-stopped
     ports:
       - "2112:2112"
     environment:
-      - STACK_AGENT_DEFAULT_TOKEN=${STACK_AGENT_DEFAULT_TOKEN}
-      - STACK_AGENT_LOG_LEVEL=info
-      - STACK_AGENT_HTTP_ADDR=:2112
+      - STEWARD_DEFAULT_TOKEN=${STEWARD_DEFAULT_TOKEN}
+      - STEWARD_LOG_LEVEL=info
+      - STEWARD_HTTP_ADDR=:2112
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:2112/healthz || exit 1"]
       interval: 30s
@@ -67,27 +69,27 @@ services:
       start_period: 10s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./config.yaml:/opt/stack-agent/config.yaml:ro
-      - ./data:/opt/stack-agent/data
+      - ./config.yaml:/opt/steward/config.yaml:ro
+      - ./data:/opt/steward/data
 ```
 
 View logs with:
 
 ```bash
-docker logs -f stack-agent
+docker logs -f steward
 ```
 
 ## Configuration
 
-The config file is read from `/opt/stack-agent/config.yaml` (or `config.yml`) by default, preferring `.yaml`. Override the path with the `--config` flag or the `STACK_AGENT_CONFIG` environment variable.
+The config file is read from `/opt/steward/config.yaml` (or `config.yml`) by default, preferring `.yaml`. Override the path with the `--config` flag or the `STEWARD_CONFIG` environment variable.
 
 ```yaml
 # Global defaults (all overridable per stack)
 defaults:
   poll_interval: 60
   branch: main
-  work_dir: /var/lib/stack-agent/stacks
-  token: ${STACK_AGENT_DEFAULT_TOKEN}  # optional
+  work_dir: /var/lib/steward/stacks
+  token: ${STEWARD_DEFAULT_TOKEN}  # optional
 
 stacks:
   - name: immich
@@ -111,7 +113,7 @@ stacks:
 |---|---|---|---|
 | `poll_interval` | int | `60` | Polling interval in seconds. Applied to all stacks unless overridden. |
 | `branch` | string | `main` | Git branch to track. |
-| `work_dir` | string | `/opt/stack-agent/data` | Directory where repos are checked out and state is stored. |
+| `work_dir` | string | `/opt/steward/data` | Directory where repos are checked out and state is stored. |
 | `token` | string | _(empty)_ | Auth token for private repos. Supports `${ENV_VAR}` interpolation. |
 
 ### Per-stack fields
@@ -135,14 +137,14 @@ Tokens are never written to disk inside the container and never appear in log ou
 ```yaml
 # compose.yaml environment section
 environment:
-  - STACK_AGENT_DEFAULT_TOKEN=${STACK_AGENT_DEFAULT_TOKEN}
+  - STEWARD_DEFAULT_TOKEN=${STEWARD_DEFAULT_TOKEN}
 ```
 
 ```yaml
 # config.yaml
 stacks:
   - name: mystack
-    token: ${STACK_AGENT_DEFAULT_TOKEN}
+    token: ${STEWARD_DEFAULT_TOKEN}
 ```
 
 Token resolution order: per-stack `token` → `defaults.token` → empty (public repo).
@@ -151,18 +153,18 @@ Token resolution order: per-stack `token` → `defaults.token` → empty (public
 
 | Method | Example |
 |---|---|
-| Default path | `/opt/stack-agent/config.yaml` (falls back to `config.yml`) |
-| `--config` flag | `stack-agent --config /etc/stack-agent/config.yaml` |
-| Environment variable | `STACK_AGENT_CONFIG=/etc/stack-agent/config.yaml` |
+| Default path | `/opt/steward/config.yaml` (falls back to `config.yml`) |
+| `--config` flag | `steward --config /etc/steward/config.yaml` |
+| Environment variable | `STEWARD_CONFIG=/etc/steward/config.yaml` |
 
 ## Environment variables
 
 | Variable | Description |
 |---|---|
-| `STACK_AGENT_CONFIG` | Path to the config file. Equivalent to `--config`. |
-| `STACK_AGENT_LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, or `error`. Defaults to `info`. |
-| `STACK_AGENT_HTTP_ADDR` | Listen address for the HTTP server exposing `/healthz` and `/metrics`. Defaults to `:2112`. Change if port 2112 is already in use on the host (e.g. `STACK_AGENT_HTTP_ADDR=:9100`). |
-| `STACK_AGENT_DEFAULT_TOKEN` | Default auth token for private repos. Used when no per-stack `token` is set. |
+| `STEWARD_CONFIG` | Path to the config file. Equivalent to `--config`. |
+| `STEWARD_LOG_LEVEL` | Log verbosity: `debug`, `info`, `warn`, or `error`. Defaults to `info`. |
+| `STEWARD_HTTP_ADDR` | Listen address for the HTTP server exposing `/healthz` and `/metrics`. Defaults to `:2112`. Change if port 2112 is already in use on the host (e.g. `STEWARD_HTTP_ADDR=:9100`). |
+| `STEWARD_DEFAULT_TOKEN` | Default auth token for private repos. Used when no per-stack `token` is set. |
 
 ## Observability
 
@@ -172,9 +174,9 @@ Every successful deploy logs: stack name, old hash, new hash, and duration.
 
 Every error logs: stack name, operation, and error string. Tokens are redacted from all error messages before logging.
 
-Set `STACK_AGENT_LOG_LEVEL=debug` to see hash comparisons and poll timing.
+Set `STEWARD_LOG_LEVEL=debug` to see hash comparisons and poll timing.
 
-stack-agent exposes two HTTP endpoints on `STACK_AGENT_HTTP_ADDR` (default `:2112`):
+steward exposes two HTTP endpoints on `STEWARD_HTTP_ADDR` (default `:2112`):
 
 | Endpoint | Description |
 |---|---|
@@ -187,10 +189,10 @@ See `examples/monitoring/` for a Grafana dashboard and Prometheus scrape config.
 
 ```bash
 # Build the binary
-go build -o stack-agent ./cmd/stack-agent
+go build -o steward ./cmd/steward
 
 # Build the container image
-docker build -t stack-agent .
+docker build -t steward .
 ```
 
 The Dockerfile uses a two-stage build: Go 1.26 Alpine builder, Alpine 3.21 runtime. The binary runs as a non-root user (`agent`, uid 1000). No git binary is included in the image — go-git is pure Go.

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -14,13 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/agent"
-	"github.com/b0rked-dev/stack-agent/internal/compose"
-	"github.com/b0rked-dev/stack-agent/internal/config"
-	"github.com/b0rked-dev/stack-agent/internal/git"
-	"github.com/b0rked-dev/stack-agent/internal/metrics"
-	"github.com/b0rked-dev/stack-agent/internal/server"
-	"github.com/b0rked-dev/stack-agent/internal/state"
+	"github.com/b0rked-dev/steward/internal/agent"
+	"github.com/b0rked-dev/steward/internal/compose"
+	"github.com/b0rked-dev/steward/internal/config"
+	"github.com/b0rked-dev/steward/internal/git"
+	"github.com/b0rked-dev/steward/internal/metrics"
+	"github.com/b0rked-dev/steward/internal/server"
+	"github.com/b0rked-dev/steward/internal/state"
 )
 
 // Version is set at build time via -ldflags "-X main.Version=<tag>".
@@ -47,11 +47,11 @@ func main() {
 func run(args []string, stdout, stderr io.Writer) int {
 	startTime := time.Now()
 
-	fs := flag.NewFlagSet("stack-agent", flag.ContinueOnError)
+	fs := flag.NewFlagSet("steward", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 
-	defaultConfig := findConfigFile("/opt/stack-agent")
-	if envPath := os.Getenv("STACK_AGENT_CONFIG"); envPath != "" {
+	defaultConfig := findConfigFile("/opt/steward")
+	if envPath := os.Getenv("STEWARD_CONFIG"); envPath != "" {
 		defaultConfig = envPath
 	}
 
@@ -61,9 +61,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Configure slog based on STACK_AGENT_LOG_LEVEL.
+	// Configure slog based on STEWARD_LOG_LEVEL.
 	level := slog.LevelInfo
-	if lvlStr := os.Getenv("STACK_AGENT_LOG_LEVEL"); lvlStr != "" {
+	if lvlStr := os.Getenv("STEWARD_LOG_LEVEL"); lvlStr != "" {
 		switch strings.ToLower(lvlStr) {
 		case "debug":
 			level = slog.LevelDebug
@@ -82,11 +82,11 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// Load config.
 	cfg, err := config.Load(*configPath)
 	if err != nil {
-		fmt.Fprintf(stderr, "stack-agent: failed to load config %q: %v\n", *configPath, err)
+		fmt.Fprintf(stderr, "steward: failed to load config %q: %v\n", *configPath, err)
 		return 1
 	}
 
-	httpAddr := os.Getenv("STACK_AGENT_HTTP_ADDR")
+	httpAddr := os.Getenv("STEWARD_HTTP_ADDR")
 	if httpAddr == "" {
 		httpAddr = ":2112"
 	}
@@ -95,7 +95,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	for i, sc := range cfg.Stacks {
 		stackNames[i] = sc.Name
 	}
-	slog.Info("stack-agent starting",
+	slog.Info("steward starting",
 		"version", Version,
 		"config", *configPath,
 		"stacks", len(cfg.Stacks),
@@ -114,14 +114,14 @@ func run(args []string, stdout, stderr io.Writer) int {
 	gitClient := git.New()
 	composeRunner := compose.NewDockerRunner()
 
-	workDir := "/opt/stack-agent/data"
+	workDir := "/opt/steward/data"
 	if len(cfg.Stacks) > 0 {
 		workDir = cfg.Stacks[0].WorkDir
 	}
 	statePath := filepath.Join(workDir, ".state.json")
 	stateStore, err := state.NewFileStore(statePath)
 	if err != nil {
-		fmt.Fprintf(stderr, "stack-agent: failed to initialize state store: %v\n", err)
+		fmt.Fprintf(stderr, "steward: failed to initialize state store: %v\n", err)
 		return 1
 	}
 

--- a/cmd/steward/main_test.go
+++ b/cmd/steward/main_test.go
@@ -136,7 +136,7 @@ stacks:
 			t.Errorf("expected exit code 0, got %d", result.code)
 		}
 		logs := result.stderr
-		if !strings.Contains(logs, "stack-agent starting") {
+		if !strings.Contains(logs, "steward starting") {
 			t.Errorf("startup banner not found in logs:\n%s", logs)
 		}
 		if !strings.Contains(logs, cfgPath) {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -2,8 +2,8 @@
 defaults:
   poll_interval: 60
   branch: main
-  # work_dir defaults to /opt/stack-agent/data — omit unless you need a custom path
-  # token is not required — stack-agent falls back to STACK_AGENT_DEFAULT_TOKEN automatically
+  # work_dir defaults to /opt/steward/data — omit unless you need a custom path
+  # token is not required — steward falls back to STEWARD_DEFAULT_TOKEN automatically
 
 stacks:
   - name: immich

--- a/docs/stack-agent-impl.md
+++ b/docs/stack-agent-impl.md
@@ -1,4 +1,4 @@
-# stack-agent: Implementation Specification
+# steward: Implementation Specification
 
 A lightweight per-host daemon written in Go that watches Git repositories for
 changes to Docker Compose stacks and reconciles running state automatically.
@@ -27,9 +27,9 @@ changes to Docker Compose stacks and reconciles running state automatically.
 ## Project Layout
 
 ```
-stack-agent/
+steward/
 ├── cmd/
-│   └── stack-agent/
+│   └── steward/
 │       └── main.go          # Entry point, signal handling, wiring
 ├── internal/
 │   ├── config/
@@ -49,7 +49,7 @@ stack-agent/
 │       └── agent_test.go
 ├── config.example.yml
 ├── Dockerfile
-├── compose.yml              # For running stack-agent itself
+├── compose.yml              # For running steward itself
 └── README.md
 ```
 
@@ -57,16 +57,16 @@ stack-agent/
 
 ## Configuration
 
-Defined in `/etc/stack-agent/config.yml` (path overridable via `--config` flag
-or `STACK_AGENT_CONFIG` env var).
+Defined in `/etc/steward/config.yml` (path overridable via `--config` flag
+or `STEWARD_CONFIG` env var).
 
 ```yaml
 # Global defaults (all overridable per stack)
 defaults:
   poll_interval: 60          # seconds
   branch: main
-  work_dir: /var/lib/stack-agent/stacks
-  token: ${STACK_AGENT_DEFAULT_TOKEN}  # optional, env var interpolated
+  work_dir: /var/lib/steward/stacks
+  token: ${STEWARD_DEFAULT_TOKEN}  # optional, env var interpolated
 
 stacks:
   - name: immich
@@ -307,7 +307,7 @@ failed deploy will be retried on the next poll.
 
 ---
 
-### `cmd/stack-agent`
+### `cmd/steward`
 
 Entry point. Responsibilities:
 
@@ -329,19 +329,19 @@ Entry point. Responsibilities:
 The agent ships as a container and is deployed as its own compose stack on each host.
 
 ```yaml
-# /opt/stacks/stack-agent/compose.yml
+# /opt/stacks/steward/compose.yml
 services:
-  stack-agent:
-    image: ghcr.io/mtc/stack-agent:latest
+  steward:
+    image: ghcr.io/mtc/steward:latest
     restart: unless-stopped
     environment:
       - HOST_SERVICES_TOKEN=${HOST_SERVICES_TOKEN}  # token passed from host env
-      - STACK_AGENT_LOG_LEVEL=info
+      - STEWARD_LOG_LEVEL=info
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - /etc/stack-agent/config.yml:/etc/stack-agent/config.yml:ro
+      - /etc/steward/config.yml:/etc/steward/config.yml:ro
       - /etc/stacks:/etc/stacks:ro          # host-local env files
-      - /var/lib/stack-agent:/var/lib/stack-agent  # state + work dir
+      - /var/lib/steward:/var/lib/steward  # state + work dir
 ```
 
 Tokens are passed into the container via environment variables and referenced
@@ -351,7 +351,7 @@ disk inside the container and never appear in logs.
 The host-side `.env` file for the compose stack holds the actual token values:
 
 ```bash
-# /opt/stacks/stack-agent/.env  (chmod 600, outside the repo)
+# /opt/stacks/steward/.env  (chmod 600, outside the repo)
 HOST_SERVICES_TOKEN=ghp_abc123...
 ```
 
@@ -362,11 +362,11 @@ No git binary is required in the image — `go-git` is pure Go.
 ## Observability
 
 - All output to stdout/stderr (structured with `log/slog`)
-- Log level configurable via `STACK_AGENT_LOG_LEVEL` (debug, info, warn, error)
+- Log level configurable via `STEWARD_LOG_LEVEL` (debug, info, warn, error)
 - Every deploy logs: stack name, old hash, new hash, duration, success/failure
 - Every error logs: stack name, operation, error string
 
-No metrics endpoint in v1. `docker logs stack-agent` is sufficient.
+No metrics endpoint in v1. `docker logs steward` is sufficient.
 
 ---
 
@@ -389,10 +389,10 @@ go test ./...
 go test -race ./...
 
 # Build binary
-go build -o stack-agent ./cmd/stack-agent
+go build -o steward ./cmd/steward
 
 # Build container
-docker build -t stack-agent .
+docker build -t steward .
 ```
 
 Tests use interface mocks for `git.Client`, `compose.Runner`, and `state.Store`
@@ -424,7 +424,7 @@ on developer machines to run the standard test suite.
 ## Future Considerations (v2+)
 
 - Webhook receiver as an alternative to polling (faster deploys)
-- `stack-agent status` CLI subcommand to show current state
+- `steward status` CLI subcommand to show current state
 - Slack/webhook notification on deploy success or failure
 - Support for multiple repos (already supported by config structure)
 - Health check endpoint (`/healthz`) for container orchestration

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -1,17 +1,17 @@
 services:
-  stack-agent:
-    image: ghcr.io/b0rked-dev/stack-agent:latest
+  steward:
+    image: ghcr.io/b0rked-dev/steward:latest
     restart: unless-stopped
     ports:
       - "2112:2112"
     environment:
-      # Token for private repos. Resolves via STACK_AGENT_DEFAULT_TOKEN env var.
+      # Token for private repos. Resolves via STEWARD_DEFAULT_TOKEN env var.
       # Remove if all your repos are public.
-      - STACK_AGENT_DEFAULT_TOKEN=${STACK_AGENT_DEFAULT_TOKEN}
-      - STACK_AGENT_LOG_LEVEL=info
+      - STEWARD_DEFAULT_TOKEN=${STEWARD_DEFAULT_TOKEN}
+      - STEWARD_LOG_LEVEL=info
       # Address for the HTTP server that exposes /healthz and /metrics (Prometheus).
       # Defaults to :2112 when unset. Change if port 2112 is already in use.
-      - STACK_AGENT_HTTP_ADDR=:2112
+      - STEWARD_HTTP_ADDR=:2112
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://localhost:2112/healthz || exit 1"]
       interval: 30s
@@ -20,5 +20,5 @@ services:
       start_period: 10s
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./config.yaml:/opt/stack-agent/config.yaml:ro
-      - ./data:/opt/stack-agent/data
+      - ./config.yaml:/opt/steward/config.yaml:ro
+      - ./data:/opt/steward/data

--- a/examples/monitoring/README.md
+++ b/examples/monitoring/README.md
@@ -1,17 +1,17 @@
-# stack-agent monitoring
+# steward monitoring
 
-Grafana dashboard and Prometheus scrape config for stack-agent.
+Grafana dashboard and Prometheus scrape config for steward.
 
 ## Files
 
 | File | Description |
 |---|---|
-| `stack-agent-dashboard.json` | Pre-built Grafana dashboard — import via the Grafana UI |
+| `steward-dashboard.json` | Pre-built Grafana dashboard — import via the Grafana UI |
 | `prometheus-scrape.yaml` | Scrape job snippet — add to your `scrape_configs` |
 
 ## Grafana dashboard
 
-Import `stack-agent-dashboard.json` via **Dashboards → Import** in the Grafana UI, or drop it into your provisioning directory. Select your Prometheus datasource when prompted.
+Import `steward-dashboard.json` via **Dashboards → Import** in the Grafana UI, or drop it into your provisioning directory. Select your Prometheus datasource when prompted.
 
 ### Panels
 
@@ -25,14 +25,14 @@ Import `stack-agent-dashboard.json` via **Dashboards → Import** in the Grafana
 
 ## Prometheus scrape config
 
-Add the contents of `prometheus-scrape.yaml` to the `scrape_configs` section of your `prometheus.yaml`, adjusting the target address to match your stack-agent host:
+Add the contents of `prometheus-scrape.yaml` to the `scrape_configs` section of your `prometheus.yaml`, adjusting the target address to match your steward host:
 
 ```yaml
 scrape_configs:
-  - job_name: stack-agent
+  - job_name: steward
     static_configs:
       - targets:
-          - <stack-agent-host>:2112
+          - <steward-host>:2112
 ```
 
-stack-agent exposes metrics at `:2112/metrics` by default. Override with the `STACK_AGENT_HTTP_ADDR` environment variable.
+steward exposes metrics at `:2112/metrics` by default. Override with the `STEWARD_HTTP_ADDR` environment variable.

--- a/examples/monitoring/prometheus-scrape.yaml
+++ b/examples/monitoring/prometheus-scrape.yaml
@@ -3,7 +3,7 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: stack-agent
+  - job_name: steward
     static_configs:
       - targets:
-          - stack-agent:2112
+          - steward:2112

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/b0rked-dev/stack-agent
+module github.com/b0rked-dev/steward
 
 go 1.26
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/compose"
-	"github.com/b0rked-dev/stack-agent/internal/config"
-	"github.com/b0rked-dev/stack-agent/internal/git"
-	"github.com/b0rked-dev/stack-agent/internal/metrics"
-	"github.com/b0rked-dev/stack-agent/internal/state"
+	"github.com/b0rked-dev/steward/internal/compose"
+	"github.com/b0rked-dev/steward/internal/config"
+	"github.com/b0rked-dev/steward/internal/git"
+	"github.com/b0rked-dev/steward/internal/metrics"
+	"github.com/b0rked-dev/steward/internal/state"
 )
 
 // Stack is a single stack poller. One goroutine per configured stack.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/config"
-	"github.com/b0rked-dev/stack-agent/internal/metrics"
+	"github.com/b0rked-dev/steward/internal/config"
+	"github.com/b0rked-dev/steward/internal/metrics"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/compose/runner.go
+++ b/internal/compose/runner.go
@@ -11,7 +11,7 @@ import (
 	"path/filepath"
 )
 
-// Runner provides docker compose operations used by stack-agent.
+// Runner provides docker compose operations used by steward.
 type Runner interface {
 	// Up runs: docker compose [--project-name <projectName>] -f <composePath> [--env-file <envFile>] up -d --remove-orphans
 	// projectName is optional; pass empty string to omit it and let Docker derive the name from the directory.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -92,9 +92,9 @@ func mergeStack(raw rawStack, defaults rawDefaults) StackConfig {
 		token = raw.Token
 	}
 	token = interpolate(token)
-	// Implicit fallback: if no token was configured, check STACK_AGENT_DEFAULT_TOKEN.
+	// Implicit fallback: if no token was configured, check STEWARD_DEFAULT_TOKEN.
 	if token == "" {
-		token = os.Getenv("STACK_AGENT_DEFAULT_TOKEN")
+		token = os.Getenv("STEWARD_DEFAULT_TOKEN")
 	}
 
 	pollInterval := defaults.PollInterval
@@ -155,7 +155,7 @@ func Load(path string) (*Config, error) {
 
 	// Apply default work_dir when not set.
 	if defaults.WorkDir == "" {
-		defaults.WorkDir = "/opt/stack-agent/data"
+		defaults.WorkDir = "/opt/steward/data"
 	}
 
 	// Validate and merge stacks.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -24,8 +24,8 @@ const validYAML = `
 defaults:
   poll_interval: 60
   branch: main
-  work_dir: /var/lib/stack-agent/stacks
-  token: ${STACK_AGENT_DEFAULT_TOKEN}
+  work_dir: /var/lib/steward/stacks
+  token: ${STEWARD_DEFAULT_TOKEN}
 
 stacks:
   - name: immich
@@ -340,7 +340,7 @@ stacks:
 }
 
 func TestLoad_ImplicitDefaultToken(t *testing.T) {
-	t.Setenv("STACK_AGENT_DEFAULT_TOKEN", "implicit-token")
+	t.Setenv("STEWARD_DEFAULT_TOKEN", "implicit-token")
 
 	p := writeTemp(t, `
 stacks:
@@ -375,7 +375,7 @@ stacks:
 }
 
 func TestLoad_ExplicitTokenOverridesImplicit(t *testing.T) {
-	t.Setenv("STACK_AGENT_DEFAULT_TOKEN", "implicit-token")
+	t.Setenv("STEWARD_DEFAULT_TOKEN", "implicit-token")
 	t.Setenv("MY_TOKEN", "explicit-token")
 
 	p := writeTemp(t, `

--- a/internal/metrics/recorder_test.go
+++ b/internal/metrics/recorder_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/metrics"
+	"github.com/b0rked-dev/steward/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 )

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/server"
+	"github.com/b0rked-dev/steward/internal/server"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/stack-agent/internal/agent"
-	"github.com/b0rked-dev/stack-agent/internal/compose"
-	"github.com/b0rked-dev/stack-agent/internal/config"
-	"github.com/b0rked-dev/stack-agent/internal/git"
-	"github.com/b0rked-dev/stack-agent/internal/state"
+	"github.com/b0rked-dev/steward/internal/agent"
+	"github.com/b0rked-dev/steward/internal/compose"
+	"github.com/b0rked-dev/steward/internal/config"
+	"github.com/b0rked-dev/steward/internal/git"
+	"github.com/b0rked-dev/steward/internal/state"
 )
 
 const (


### PR DESCRIPTION
Closes #40.

## Summary
- Binary: `stack-agent` → `steward`
- `cmd/stack-agent/` → `cmd/steward/`
- Go module: `github.com/b0rked-dev/stack-agent` → `github.com/b0rked-dev/steward`
- Docker image: `ghcr.io/b0rked-dev/stack-agent` → `ghcr.io/b0rked-dev/steward`
- Env vars: `STACK_AGENT_*` → `STEWARD_*`
- Paths: `/opt/stack-agent` → `/opt/steward`
- README: new tagline — _Steward — continuous reconciliation for Docker Compose stacks_

## Test plan
- [ ] CI passes