### PR TITLE
chore: rename project from stack-agent to steward

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/b0rked-dev/steward
+          images: ghcr.io/rcarson/steward
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The `examples/docker-compose/compose.yaml` in this repository is the deployment 
 ```yaml
 services:
   steward:
-    image: ghcr.io/b0rked-dev/steward:latest
+    image: ghcr.io/rcarson/steward:latest
     restart: unless-stopped
     ports:
       - "2112:2112"

--- a/cmd/steward/main.go
+++ b/cmd/steward/main.go
@@ -14,13 +14,13 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/agent"
-	"github.com/b0rked-dev/steward/internal/compose"
-	"github.com/b0rked-dev/steward/internal/config"
-	"github.com/b0rked-dev/steward/internal/git"
-	"github.com/b0rked-dev/steward/internal/metrics"
-	"github.com/b0rked-dev/steward/internal/server"
-	"github.com/b0rked-dev/steward/internal/state"
+	"github.com/rcarson/steward/internal/agent"
+	"github.com/rcarson/steward/internal/compose"
+	"github.com/rcarson/steward/internal/config"
+	"github.com/rcarson/steward/internal/git"
+	"github.com/rcarson/steward/internal/metrics"
+	"github.com/rcarson/steward/internal/server"
+	"github.com/rcarson/steward/internal/state"
 )
 
 // Version is set at build time via -ldflags "-X main.Version=<tag>".

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -1,6 +1,6 @@
 services:
   steward:
-    image: ghcr.io/b0rked-dev/steward:latest
+    image: ghcr.io/rcarson/steward:latest
     restart: unless-stopped
     ports:
       - "2112:2112"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/b0rked-dev/steward
+module github.com/rcarson/steward
 
 go 1.26
 

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/compose"
-	"github.com/b0rked-dev/steward/internal/config"
-	"github.com/b0rked-dev/steward/internal/git"
-	"github.com/b0rked-dev/steward/internal/metrics"
-	"github.com/b0rked-dev/steward/internal/state"
+	"github.com/rcarson/steward/internal/compose"
+	"github.com/rcarson/steward/internal/config"
+	"github.com/rcarson/steward/internal/git"
+	"github.com/rcarson/steward/internal/metrics"
+	"github.com/rcarson/steward/internal/state"
 )
 
 // Stack is a single stack poller. One goroutine per configured stack.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/config"
-	"github.com/b0rked-dev/steward/internal/metrics"
+	"github.com/rcarson/steward/internal/config"
+	"github.com/rcarson/steward/internal/metrics"
 )
 
 // ---------------------------------------------------------------------------

--- a/internal/metrics/recorder_test.go
+++ b/internal/metrics/recorder_test.go
@@ -4,9 +4,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/rcarson/steward/internal/metrics"
 )
 
 // gatherCounter gathers all metrics from reg and returns the value of the

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/server"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rcarson/steward/internal/server"
 )
 
 func TestHealthz(t *testing.T) {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -10,11 +10,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/b0rked-dev/steward/internal/agent"
-	"github.com/b0rked-dev/steward/internal/compose"
-	"github.com/b0rked-dev/steward/internal/config"
-	"github.com/b0rked-dev/steward/internal/git"
-	"github.com/b0rked-dev/steward/internal/state"
+	"github.com/rcarson/steward/internal/agent"
+	"github.com/rcarson/steward/internal/compose"
+	"github.com/rcarson/steward/internal/config"
+	"github.com/rcarson/steward/internal/git"
+	"github.com/rcarson/steward/internal/state"
 )
 
 const (


### PR DESCRIPTION
Closes #40.

## Summary
- Binary: `stack-agent` → `steward`
- `cmd/stack-agent/` → `cmd/steward/`
- Go module: `github.com/rcarson/stack-agent` → `github.com/rcarson/steward`
- Docker image: `ghcr.io/rcarson/stack-agent` → `ghcr.io/rcarson/steward`
- Env vars: `STACK_AGENT_*` → `STEWARD_*`
- Paths: `/opt/stack-agent` → `/opt/steward`
- README: new tagline — _Steward — continuous reconciliation for Docker Compose stacks_

## Test plan
- [ ] CI passes