### PR TITLE
fix: run container as root instead of non-root agent user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,10 @@ RUN go build -ldflags "-X main.Version=${VERSION}" -o /steward ./cmd/steward
 
 FROM alpine:3.21
 
-RUN adduser -D -u 1000 agent && mkdir -p /opt/steward/data && chown -R agent:agent /opt/steward
+RUN mkdir -p /opt/steward/data
 
 COPY --from=builder /steward /steward
 
-USER agent
 WORKDIR /opt/steward
 
 EXPOSE 2112

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ go build -o steward ./cmd/steward
 docker build -t steward .
 ```
 
-The Dockerfile uses a two-stage build: Go 1.26 Alpine builder, Alpine 3.21 runtime. The binary runs as a non-root user (`agent`, uid 1000). No git binary is included in the image — go-git is pure Go.
+The Dockerfile uses a two-stage build: Go 1.26 Alpine builder, Alpine 3.21 runtime. The binary runs as root (required for Docker socket access). No git binary is included in the image — go-git is pure Go.
 
 ## Running tests
 


### PR DESCRIPTION
Closes #43.

## Summary
- Removes `agent` user (uid 1000) from Dockerfile
- Runs as root — required for Docker socket access, which is root-equivalent anyway
- Fixes permission denied errors on bind-mounted `./data` directories

## Test plan
- [ ] CI passes
- [ ] Container starts and can write to bind-mounted data directory