### PR TITLE
fix: switch runtime base image to docker:27-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /build
 COPY . .
 RUN go build -ldflags "-X main.Version=${VERSION}" -o /steward ./cmd/steward
 
-FROM alpine:3.21
+FROM docker:27-cli
 
 RUN mkdir -p /opt/steward/data
 

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ go build -o steward ./cmd/steward
 docker build -t steward .
 ```
 
-The Dockerfile uses a two-stage build: Go 1.26 Alpine builder, Alpine 3.21 runtime. The binary runs as root (required for Docker socket access). No git binary is included in the image — go-git is pure Go.
+The Dockerfile uses a two-stage build: Go 1.26 Alpine builder, docker:27-cli runtime. The binary runs as root (required for Docker socket access). No git binary is included in the image — go-git is pure Go.
 
 ## Running tests
 


### PR DESCRIPTION
Closes #46.

## Summary
- Replaces `alpine:3.21` runtime stage with `docker:27-cli`
- Provides the Docker CLI and Compose plugin without the daemon
- Fixes `docker binary not found` error at runtime

## Test plan
- [ ] CI passes
- [ ] Container can execute `docker compose up`