### PR TITLE
feat: split /opt/steward into config/ and data/ directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN go build -ldflags "-X main.Version=${VERSION}" -o /steward ./cmd/steward
 
 FROM docker:27-cli
 
-RUN mkdir -p /opt/steward/data
+RUN mkdir -p /opt/steward/config /opt/steward/data
 
 COPY --from=builder /steward /steward
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Git operations use [go-git](https://github.com/go-git/go-git), a pure Go impleme
 **1. Create the directory layout on the host.**
 
 ```bash
-mkdir -p /opt/steward/data
+mkdir -p /opt/steward/config /opt/steward/data
 ```
 
 **2. Write a config file.**
@@ -70,6 +70,7 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config.yaml:/opt/steward/config.yaml:ro
+      - ./config:/opt/steward/config:ro
       - ./data:/opt/steward/data
 ```
 
@@ -114,6 +115,7 @@ stacks:
 | `poll_interval` | int | `60` | Polling interval in seconds. Applied to all stacks unless overridden. |
 | `branch` | string | `main` | Git branch to track. |
 | `work_dir` | string | `/opt/steward/data` | Directory where repos are checked out and state is stored. |
+| `config_dir` | string | `/opt/steward/config` | Directory where per-stack env files are looked up by default. |
 | `token` | string | _(empty)_ | Auth token for private repos. Supports `${ENV_VAR}` interpolation. |
 
 ### Per-stack fields
@@ -125,7 +127,7 @@ stacks:
 | `path` | yes | Subdirectory within the repo that contains the `compose.yml`. |
 | `branch` | no | Overrides `defaults.branch`. |
 | `token` | no | Overrides `defaults.token`. |
-| `env_file` | no | Relative path (from `work_dir`) to an env file passed to compose as `--env-file`. Defaults to `{name}.env` in `work_dir` if that file exists. |
+| `env_file` | no | Path to an env file passed to compose as `--env-file`. Absolute paths are used as-is; relative paths resolve from `config_dir`. Defaults to `{config_dir}/{name}.env` if that file exists. |
 | `poll_interval` | no | Overrides `defaults.poll_interval`. Minimum: `10` seconds. |
 
 ### Token and environment variable interpolation

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -3,6 +3,7 @@ defaults:
   poll_interval: 60
   branch: main
   # work_dir defaults to /opt/steward/data — omit unless you need a custom path
+  # config_dir defaults to /opt/steward/config — where <stack>.env files are looked up
   # token is not required — steward falls back to STEWARD_DEFAULT_TOKEN automatically
 
 stacks:
@@ -11,8 +12,8 @@ stacks:
     path: stacks/immich
     branch: main
     poll_interval: 60
-    # env_file defaults to {work_dir}/immich.env if the file exists — omit if not needed
-    # env_file: immich.env  # relative to work_dir
+    # env_file defaults to {config_dir}/immich.env if the file exists — omit if not needed
+    # env_file: immich.env  # relative to config_dir, or use an absolute path
 
   - name: nextcloud
     repo: https://github.com/example/host-services.git

--- a/examples/docker-compose/compose.yaml
+++ b/examples/docker-compose/compose.yaml
@@ -21,4 +21,5 @@ services:
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
       - ./config.yaml:/opt/steward/config.yaml:ro
+      - ./config:/opt/steward/config:ro
       - ./data:/opt/steward/data

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -108,8 +108,8 @@ func (s *Stack) poll(ctx context.Context) {
 		return
 	}
 
-	// Step 5: resolve env file relative to work_dir.
-	envFile := resolveEnvFile(s.cfg.WorkDir, s.cfg.Name, s.cfg.EnvFile)
+	// Step 5: resolve env file from config_dir.
+	envFile := resolveEnvFile(s.cfg.ConfigDir, s.cfg.Name, s.cfg.EnvFile)
 
 	// Step 6: run compose up.
 	if err := s.compose.Up(ctx, composePath, envFile, s.cfg.Name); err != nil {
@@ -135,13 +135,17 @@ func (s *Stack) poll(ctx context.Context) {
 }
 
 // resolveEnvFile returns the absolute path to the env file for a stack.
-// If envFile is set, it is resolved relative to workDir.
-// Otherwise, {workDir}/{name}.env is used if it exists; empty string if not.
-func resolveEnvFile(workDir, name, envFile string) string {
+// If envFile is set and absolute, it is used as-is. If relative, it is
+// resolved relative to configDir. Otherwise, {configDir}/{name}.env is
+// used if it exists; empty string if not.
+func resolveEnvFile(configDir, name, envFile string) string {
 	if envFile != "" {
-		return filepath.Join(workDir, envFile)
+		if filepath.IsAbs(envFile) {
+			return envFile
+		}
+		return filepath.Join(configDir, envFile)
 	}
-	candidate := filepath.Join(workDir, name+".env")
+	candidate := filepath.Join(configDir, name+".env")
 	if _, err := os.Stat(candidate); err == nil {
 		return candidate
 	}

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -125,6 +125,7 @@ func stackCfg(name string) config.StackConfig {
 		Branch:       "main",
 		Path:         "services/app",
 		WorkDir:      "/tmp/stacks",
+		ConfigDir:    "/tmp/config",
 		PollInterval: 0,
 	}
 }
@@ -465,5 +466,14 @@ func TestResolveEnvFile_DefaultMissing(t *testing.T) {
 	got := resolveEnvFile(dir, "mystack", "")
 	if got != "" {
 		t.Errorf("expected empty string when default env file missing, got %q", got)
+	}
+}
+
+func TestResolveEnvFile_ExplicitAbsolutePath(t *testing.T) {
+	dir := t.TempDir()
+	abs := "/etc/stacks/mystack.env"
+	got := resolveEnvFile(dir, "mystack", abs)
+	if got != abs {
+		t.Errorf("expected absolute path %q to be used as-is, got %q", abs, got)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -16,6 +15,7 @@ type rawDefaults struct {
 	PollInterval int    `yaml:"poll_interval"`
 	Branch       string `yaml:"branch"`
 	WorkDir      string `yaml:"work_dir"`
+	ConfigDir    string `yaml:"config_dir"`
 	Token        string `yaml:"token"`
 }
 
@@ -47,6 +47,7 @@ type StackConfig struct {
 	EnvFile      string
 	ComposeFile  string
 	WorkDir      string
+	ConfigDir    string
 	PollInterval int
 }
 
@@ -74,6 +75,7 @@ func interpolate(s string) string {
 func interpolateDefaults(d rawDefaults) rawDefaults {
 	d.Branch = interpolate(d.Branch)
 	d.WorkDir = interpolate(d.WorkDir)
+	d.ConfigDir = interpolate(d.ConfigDir)
 	d.Token = interpolate(d.Token)
 	return d
 }
@@ -111,6 +113,7 @@ func mergeStack(raw rawStack, defaults rawDefaults) StackConfig {
 		EnvFile:      interpolate(raw.EnvFile),
 		ComposeFile:  interpolate(raw.ComposeFile),
 		WorkDir:      defaults.WorkDir,
+		ConfigDir:    defaults.ConfigDir,
 		PollInterval: pollInterval,
 	}
 }
@@ -158,6 +161,11 @@ func Load(path string) (*Config, error) {
 		defaults.WorkDir = "/opt/steward/data"
 	}
 
+	// Apply default config_dir when not set.
+	if defaults.ConfigDir == "" {
+		defaults.ConfigDir = "/opt/steward/config"
+	}
+
 	// Validate and merge stacks.
 	seenNames := make(map[string]struct{}, len(raw.Stacks))
 	stacks := make([]StackConfig, 0, len(raw.Stacks))
@@ -183,11 +191,6 @@ func Load(path string) (*Config, error) {
 		}
 		seenNames[merged.Name] = struct{}{}
 
-		// Validate env_file is relative (not absolute).
-		if filepath.IsAbs(merged.EnvFile) {
-			return nil, fmt.Errorf("config: stack %q: env_file must be a relative path (got %q); it is resolved relative to work_dir", merged.Name, merged.EnvFile)
-		}
-
 		// Validate repo URL scheme.
 		if !isHTTPS(merged.Repo) {
 			return nil, fmt.Errorf("config: stack %q: repo must use HTTPS URL (got %q); SSH and other protocols are not supported", merged.Name, merged.Repo)
@@ -196,7 +199,6 @@ func Load(path string) (*Config, error) {
 		// Validate poll_interval minimum.
 		const minPollInterval = 10
 		if merged.PollInterval < minPollInterval {
-			// Build the error without the token.
 			msg := fmt.Sprintf("config: stack %q: poll_interval must be at least %d seconds (got %d)", merged.Name, minPollInterval, merged.PollInterval)
 			msg = redactToken(msg, merged.Token)
 			return nil, fmt.Errorf("%s", msg)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -357,7 +357,7 @@ stacks:
 	}
 }
 
-func TestLoad_AbsoluteEnvFileRejected(t *testing.T) {
+func TestLoad_AbsoluteEnvFileAccepted(t *testing.T) {
 	p := writeTemp(t, `
 stacks:
   - name: mystack
@@ -365,12 +365,28 @@ stacks:
     path: stacks/mystack
     env_file: /etc/stacks/mystack.env
 `)
-	_, err := Load(p)
-	if err == nil {
-		t.Fatal("expected error for absolute env_file, got nil")
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("expected absolute env_file to be accepted, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "relative") {
-		t.Errorf("error should mention 'relative', got: %v", err)
+	if cfg.Stacks[0].EnvFile != "/etc/stacks/mystack.env" {
+		t.Errorf("expected env_file %q, got %q", "/etc/stacks/mystack.env", cfg.Stacks[0].EnvFile)
+	}
+}
+
+func TestLoad_ConfigDirDefault(t *testing.T) {
+	p := writeTemp(t, `
+stacks:
+  - name: mystack
+    repo: https://github.com/example/repo.git
+    path: stacks/mystack
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Stacks[0].ConfigDir != "/opt/steward/config" {
+		t.Errorf("expected default config_dir %q, got %q", "/opt/steward/config", cfg.Stacks[0].ConfigDir)
 	}
 }
 


### PR DESCRIPTION
Closes #48.

## Summary
- Adds `config_dir` to defaults (default: `/opt/steward/config`) — where per-stack env files live
- `resolveEnvFile` now looks in `config_dir` instead of `work_dir`
- Absolute `env_file` paths are accepted as-is (previously rejected)
- Dockerfile creates both `/opt/steward/config` and `/opt/steward/data`
- Compose example mounts `./config` and `./data` as separate volumes

## Directory layout
```
/opt/steward/
  config/        ← user-provided: <stack>.env files
  data/          ← steward-generated: repo checkouts, .state.json
  config.yaml    ← steward config (mounted separately)
```

## Test plan
- [ ] CI passes
- [ ] `mealie.env` in `config/` is picked up automatically without explicit `env_file` in config