### PR TITLE
fix: default branch to "main" when not set in config

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -88,6 +88,9 @@ func mergeStack(raw rawStack, defaults rawDefaults) StackConfig {
 		branch = raw.Branch
 	}
 	branch = interpolate(branch)
+	if branch == "" {
+		branch = "main"
+	}
 
 	token := defaults.Token
 	if raw.Token != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -390,6 +390,22 @@ stacks:
 	}
 }
 
+func TestLoad_BranchDefaultsToMain(t *testing.T) {
+	p := writeTemp(t, `
+stacks:
+  - name: mystack
+    repo: https://github.com/example/repo.git
+    path: stacks/mystack
+`)
+	cfg, err := Load(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Stacks[0].Branch != "main" {
+		t.Errorf("expected default branch %q, got %q", "main", cfg.Stacks[0].Branch)
+	}
+}
+
 func TestLoad_ExplicitTokenOverridesImplicit(t *testing.T) {
 	t.Setenv("STEWARD_DEFAULT_TOKEN", "implicit-token")
 	t.Setenv("MY_TOKEN", "explicit-token")


### PR DESCRIPTION
## Summary

- When `branch` is omitted from both the stack and defaults, the resolved value was an empty string
- This caused a runtime error: `git: branch "" not found in remote "..."`
- `mergeStack` now falls back to `"main"` if branch is still empty after interpolation

Closes #52.

## Test plan

- [ ] `go test ./internal/config/` passes
- [ ] Stack with no `branch` field deploys against `main`
- [ ] Explicit `branch` still overrides the default